### PR TITLE
Add sub_state field to gopay_payments

### DIFF
--- a/src/migrations/20200702134755_add_sub_state_field.php
+++ b/src/migrations/20200702134755_add_sub_state_field.php
@@ -1,0 +1,13 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddSubStateField extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('gopay_payments')
+            ->addColumn('sub_state', 'string', ['null' => true])
+            ->save();
+    }
+}


### PR DESCRIPTION
After Returning to shop from gopay, when payment was declined, unknown column sub_state error occurs.

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'sub_state' in 'field list'