### PR TITLE
Error handling

### DIFF
--- a/src/gateways/GoPayRecurrent.php
+++ b/src/gateways/GoPayRecurrent.php
@@ -114,6 +114,7 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
             throw new GatewayFail($exception->getMessage(), $exception->getCode());
         }
 
+        $this->checkChargeStatus($payment, $this->getResultCode());
         return self::CHARGE_OK;
     }
 
@@ -149,11 +150,16 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
 
     public function getResultCode()
     {
-        return $this->response->getData()['state'];
+        return $this->hasError() ? 'FAILED' : $this->response->getData()['state'];
     }
 
     public function getResultMessage()
     {
-        return $this->response->getData()['state'];
+        return $this->hasError() ? 'FAILED' : $this->response->getData()['state'];
+    }
+
+    protected function hasError(): bool
+    {
+        return !empty($this->response->getData()['errors']);
     }
 }


### PR DESCRIPTION
If there is an error in gopay (https://doc.gopay.com/en/#errors) the response does not contain the state parameter (https://doc.gopay.com/en/#return-errors), so the two methods below (getResultCode and getResultMessage) are throwing a notice, which is only logged in production, but the execution continues. And because the response status is not checked, the payment is marked as paid. I've added a simple error check, and return FAILED status, if an error occurs. I've also added the checkChargeStatus call before the charge return, which throws an exception if the payment failed.