### PR TITLE
Recurrent charge notifications

### DIFF
--- a/src/api/GoPayNotificationHandler.php
+++ b/src/api/GoPayNotificationHandler.php
@@ -32,6 +32,7 @@ class GoPayNotificationHandler extends ApiHandler
     {
         return [
             new InputParam(InputParam::TYPE_GET, 'id', InputParam::REQUIRED),
+            new InputParam(InputParam::TYPE_GET, 'parent_id', InputParam::OPTIONAL),
         ];
     }
 
@@ -49,7 +50,7 @@ class GoPayNotificationHandler extends ApiHandler
         }
         $params = $paramsProcessor->getValues();
 
-        $result = $this->gopay->notification($params['id']);
+        $result = $this->gopay->notification($params['id'], $params['parent_id'] ?? null);
         if (!$result) {
             $response = new JsonResponse(['status' => 'error', 'message' => 'payment not found']);
             $response->setHttpCode(Response::S404_NOT_FOUND);

--- a/src/gateways/BaseGoPay.php
+++ b/src/gateways/BaseGoPay.php
@@ -5,6 +5,8 @@ namespace Crm\GoPayModule\Gateways;
 use Crm\GoPayModule\Repository\GopayPaymentsRepository;
 use Crm\GoPayModule\Repository\GopayPaymentValues;
 use Crm\PaymentsModule\Gateways\GatewayAbstract;
+use Crm\PaymentsModule\RecurrentPaymentsProcessor;
+use Crm\PaymentsModule\Repository\PaymentLogsRepository;
 use Crm\PaymentsModule\Repository\PaymentsRepository;
 use Crm\PaymentsModule\Repository\RecurrentPaymentsRepository;
 use Nette\Database\Table\IRow;
@@ -20,6 +22,10 @@ abstract class BaseGoPay extends GatewayAbstract
 {
     // https://doc.gopay.com/cs/#stavy-plateb
     const STATE_PAID = 'PAID';
+    const STATE_CREATED = 'CREATED';
+    const STATE_CANCELED = 'CANCELED';
+    const STATE_TIMEOUTED = 'TIMEOUTED';
+    const STATE_AUTHORIZED = 'AUTHORIZED';
 
     // https://doc.gopay.com/en/#payment-substate
     const PENDING_PAYMENT_SUB_STATE = ['_101', '_102'];
@@ -33,7 +39,11 @@ abstract class BaseGoPay extends GatewayAbstract
 
     protected $recurrentPaymentsRepository;
 
+    protected $recurrentPaymentsProcessor;
+
     protected $eventEmitter;
+
+    protected $paymentLogsRepository;
 
     protected $eetEnabled = false;
 
@@ -44,14 +54,18 @@ abstract class BaseGoPay extends GatewayAbstract
         ITranslator $translator,
         GopayPaymentsRepository $gopayPaymentsRepository,
         PaymentsRepository $paymentsRepository,
+        RecurrentPaymentsProcessor $recurrentPaymentsProcessor,
+        PaymentLogsRepository $paymentLogsRepository,
         RecurrentPaymentsRepository $recurrentPaymentsRepository,
         Emitter $eventEmitter
     ) {
         parent::__construct($linkGenerator, $applicationConfig, $httpResponse, $translator);
         $this->paymentsRepository = $paymentsRepository;
-        $this->recurrentPaymentsRepository = $recurrentPaymentsRepository;
+        $this->recurrentPaymentsProcessor = $recurrentPaymentsProcessor;
         $this->eventEmitter = $eventEmitter;
         $this->gopayPaymentsRepository = $gopayPaymentsRepository;
+        $this->paymentLogsRepository = $paymentLogsRepository;
+        $this->recurrentPaymentsRepository = $recurrentPaymentsRepository;
     }
 
     protected function initialize()


### PR DESCRIPTION
All recurrent payments are in CREATED state in gopay after calling the charge command. Unfortunately, currently this state is handled as successfull, but it is not.. The payment can be cancelled later for various reasons (https://doc.gopay.com/en/#payment-substate). I've updated the charge function, so it sets the payment as pending if it is CREATED, until gopay sends a notification. The payment and recurrent payment are updated after the notification. I've also added logging to payment_logs and gopay_payments for recurrent transactions, which were missing.