### PR TITLE
Notification fixes

### DIFF
--- a/src/api/GoPayNotificationHandler.php
+++ b/src/api/GoPayNotificationHandler.php
@@ -9,6 +9,7 @@ use Crm\ApiModule\Params\InputParam;
 use Crm\ApiModule\Params\ParamsProcessor;
 use Crm\GoPayModule\Gateways\GoPayRecurrent;
 use Nette\Http\Response;
+use Tracy\Debugger;
 
 /**
  * Class GoPayNotificationHandler
@@ -52,8 +53,9 @@ class GoPayNotificationHandler extends ApiHandler
 
         $result = $this->gopay->notification($params['id'], $params['parent_id'] ?? null);
         if (!$result) {
-            $response = new JsonResponse(['status' => 'error', 'message' => 'payment not found']);
-            $response->setHttpCode(Response::S404_NOT_FOUND);
+            Debugger::log('Gopay notification payment not found: ' . $params['id'], Debugger::EXCEPTION);
+            $response = new JsonResponse(['status' => 'ok']);
+            $response->setHttpCode(Response::S200_OK);
             return $response;
         }
 

--- a/src/gateways/GoPayRecurrent.php
+++ b/src/gateways/GoPayRecurrent.php
@@ -2,6 +2,8 @@
 
 namespace Crm\GoPayModule\Gateways;
 
+use Crm\GoPayModule\Notification\InvalidGopayResponseException;
+use Crm\GoPayModule\Notification\PaymentNotFoundException;
 use Crm\PaymentsModule\GatewayFail;
 use Crm\PaymentsModule\Gateways\RecurrentPaymentInterface;
 use Crm\PaymentsModule\Repository\PaymentsRepository;
@@ -40,7 +42,7 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
             ->where(['transaction_reference' => $id])
             ->limit(1)->fetch();
         if (!$gopayMeta) {
-            return false;
+            throw new PaymentNotFoundException('Payment with transaction reference ' . $id . ' not found.');
         }
 
         $payment = $gopayMeta->payment;
@@ -52,6 +54,9 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
         $this->response = $this->gateway->completePurchase($request);
 
         $data = $this->response->getData();
+        if ($data === null) {
+            throw new InvalidGopayResponseException('Empty response from gopay for payment with transaction reference ' . $id);
+        }
         $this->gopayPaymentsRepository->updatePayment($payment, $this->buildGopayPaymentValues($data));
 
         $this->paymentLogsRepository->add(

--- a/src/model/Notification/InvalidGopayResponseException.php
+++ b/src/model/Notification/InvalidGopayResponseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Crm\GoPayModule\Notification;
+
+class InvalidGopayResponseException extends NotificationException
+{
+}

--- a/src/model/Notification/NotificationException.php
+++ b/src/model/Notification/NotificationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Crm\GoPayModule\Notification;
+
+use Exception;
+
+class NotificationException extends Exception
+{
+}

--- a/src/model/Notification/PaymentNotFoundException.php
+++ b/src/model/Notification/PaymentNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Crm\GoPayModule\Notification;
+
+class PaymentNotFoundException extends NotificationException
+{
+}


### PR DESCRIPTION
I've added exceptions to the recurrent gateway notification method, so we can process errors in the api handler. If the payment was not found in the gopay_payments table (PaymentNotFoundException), we log the transaction id and return 200 response (if we dont, gopay will keep sending this notification again every 10 minutes). Sometimes gopay status request does not return any data (timeout or some error happened), in this case we throw a InvalidGopayResponseException, which sends 400 response - we want gopay to send the notification again, so we can reprocess it.