### PR TITLE
Multiple notifications fix

### DIFF
--- a/src/api/GoPayNotificationHandler.php
+++ b/src/api/GoPayNotificationHandler.php
@@ -10,6 +10,7 @@ use Crm\ApiModule\Params\ParamsProcessor;
 use Crm\GoPayModule\Gateways\GoPayRecurrent;
 use Crm\GoPayModule\Notification\InvalidGopayResponseException;
 use Crm\GoPayModule\Notification\PaymentNotFoundException;
+use Crm\GoPayModule\Notification\UnhandledStateException;
 use Nette\Http\Response;
 use Tracy\Debugger;
 
@@ -61,6 +62,8 @@ class GoPayNotificationHandler extends ApiHandler
             $response->setHttpCode(Response::S400_BAD_REQUEST);
             return $response;
         } catch (PaymentNotFoundException $e) {
+            Debugger::log($e, Debugger::EXCEPTION);
+        } catch (UnhandledStateException $e) {
             Debugger::log($e, Debugger::EXCEPTION);
         }
 

--- a/src/gateways/BaseGoPay.php
+++ b/src/gateways/BaseGoPay.php
@@ -29,6 +29,7 @@ abstract class BaseGoPay extends GatewayAbstract
     const STATE_CANCELED = 'CANCELED';
     const STATE_TIMEOUTED = 'TIMEOUTED';
     const STATE_AUTHORIZED = 'AUTHORIZED';
+    const STATE_PAYMENT_METHOD_CHOSEN = 'PAYMENT_METHOD_CHOSEN';
 
     // https://doc.gopay.com/en/#payment-substate
     const PENDING_PAYMENT_SUB_STATE = ['_101', '_102'];

--- a/src/gateways/BaseGoPay.php
+++ b/src/gateways/BaseGoPay.php
@@ -116,6 +116,10 @@ abstract class BaseGoPay extends GatewayAbstract
         $this->response = $this->gateway->completePurchase($request);
 
         $data = $this->response->getData();
+        // if the gateway does not respond - wait for notification
+        if ($data === null) {
+            return null;
+        }
         $this->gopayPaymentsRepository->updatePayment($payment, $this->buildGopayPaymentValues($data));
 
         if (isset($data['sub_state']) && in_array($data['sub_state'], self::PENDING_PAYMENT_SUB_STATE)) {

--- a/src/gateways/GoPayRecurrent.php
+++ b/src/gateways/GoPayRecurrent.php
@@ -57,7 +57,6 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
         if ($data === null) {
             throw new InvalidGopayResponseException('Empty response from gopay for payment with transaction reference ' . $id);
         }
-        $this->gopayPaymentsRepository->updatePayment($payment, $this->buildGopayPaymentValues($data));
 
         $this->paymentLogsRepository->add(
             $this->response->isSuccessful() ? 'OK' : 'ERROR',
@@ -66,42 +65,62 @@ class GoPayRecurrent extends BaseGoPay implements RecurrentPaymentInterface
             $payment->id
         );
 
-        if ($payment->status != PaymentsRepository::STATUS_PAID && in_array($data['state'], [self::STATE_PAID, self::STATE_AUTHORIZED])) {
-            if ((boolean) $payment->payment_gateway->is_recurrent) {
-                $recurrentPayment = $this->recurrentPaymentsRepository->findByPayment($payment);
-                if ($recurrentPayment) {
-                    $this->recurrentPaymentsProcessor->processChargedRecurrent(
-                        $recurrentPayment,
-                        PaymentsRepository::STATUS_PAID,
-                        $this->getResultCode(),
-                        $this->getResultMessage()
-                    );
-                } else {
-                    $payment = $this->paymentsRepository->updateStatus($payment, PaymentsRepository::STATUS_PAID, true);
-                    $this->recurrentPaymentsRepository->createFromPayment(
-                        $payment,
-                        $id
-                    );
-                }
-            } else {
-                $this->paymentsRepository->updateStatus($payment, PaymentsRepository::STATUS_PAID, true);
-            }
+        if ($payment->status !== PaymentsRepository::STATUS_FORM) {
+            return true;
+        }
+
+        if (empty($data['state']) && $this->getError() !== null) {
+            $this->handleCanceled($payment, PaymentsRepository::STATUS_FAIL);
+            return true;
+        }
+        $this->gopayPaymentsRepository->updatePayment($payment, $this->buildGopayPaymentValues($data));
+
+        if (in_array($data['state'], [self::STATE_PAID, self::STATE_AUTHORIZED])) {
+            $this->handleSuccess($payment);
         }
 
         if (in_array($data['state'], [self::STATE_CANCELED, self::STATE_TIMEOUTED])) {
-            if ((boolean) $payment->payment_gateway->is_recurrent) {
-                $recurrentPayment = $this->recurrentPaymentsRepository->findByPayment($payment);
-                if ($recurrentPayment) {
-                    $this->recurrentPaymentsProcessor->processFailedRecurrent($recurrentPayment, $this->getResultCode(), $this->getResultMessage());
-                } else {
-                    $this->paymentsRepository->updateStatus($payment, $data['state'] === self::STATE_TIMEOUTED ? PaymentsRepository::STATUS_TIMEOUT : PaymentsRepository::STATUS_FAIL, true);
-                }
-            } else {
-                $this->paymentsRepository->updateStatus($payment, $data['state'] === self::STATE_TIMEOUTED ? PaymentsRepository::STATUS_TIMEOUT : PaymentsRepository::STATUS_FAIL, true);
-            }
+            $this->handleCanceled($payment, $data['state'] === self::STATE_TIMEOUTED ? PaymentsRepository::STATUS_TIMEOUT : PaymentsRepository::STATUS_FAIL);
         }
 
         return true;
+    }
+
+    protected function handleSuccess(IRow $payment)
+    {
+        if ((boolean) $payment->payment_gateway->is_recurrent) {
+            $recurrentPayment = $this->recurrentPaymentsRepository->findByPayment($payment);
+            if ($recurrentPayment) {
+                $this->recurrentPaymentsProcessor->processChargedRecurrent(
+                    $recurrentPayment,
+                    PaymentsRepository::STATUS_PAID,
+                    $this->getResultCode(),
+                    $this->getResultMessage()
+                );
+            } else {
+                $payment = $this->paymentsRepository->updateStatus($payment, PaymentsRepository::STATUS_PAID, true);
+                $this->recurrentPaymentsRepository->createFromPayment(
+                    $payment,
+                    $id
+                );
+            }
+        } else {
+            $this->paymentsRepository->updateStatus($payment, PaymentsRepository::STATUS_PAID, true);
+        }
+    }
+
+    protected function handleCanceled(IRow $payment, string $newStatus)
+    {
+        if ((boolean) $payment->payment_gateway->is_recurrent) {
+            $recurrentPayment = $this->recurrentPaymentsRepository->findByPayment($payment);
+            if ($recurrentPayment) {
+                $this->recurrentPaymentsProcessor->processFailedRecurrent($recurrentPayment, $this->getResultCode(), $this->getResultMessage());
+            } else {
+                $this->paymentsRepository->updateStatus($payment, $newStatus, true);
+            }
+        } else {
+            $this->paymentsRepository->updateStatus($payment, $newStatus, true);
+        }
     }
 
     public function getRecurrentToken()

--- a/src/model/Notification/UnhandledStateException.php
+++ b/src/model/Notification/UnhandledStateException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Crm\GoPayModule\Notification;
+
+class UnhandledStateException extends NotificationException
+{
+}


### PR DESCRIPTION
This week there were some problems at the payment gateway, and they sent the same notification a couple times to the notification endpoint (what can teoretically happen for various reasons any time - server problems, etc.), and we had dozens of active recurrent payments created. So I've added a check for this to the notification method. Sometimes instead of payment data, the gateway sends an error response to the status request, that is handled in this pr too. 