### PR TITLE
Handling payment_method_chosen state

### DIFF
--- a/src/gateways/BaseGoPay.php
+++ b/src/gateways/BaseGoPay.php
@@ -128,7 +128,7 @@ abstract class BaseGoPay extends GatewayAbstract
         }
 
         // return null state [form] - wait for notification
-        if ($data['state'] == self::STATE_CREATED) {
+        if ($this->isPendingState($data['state'])) {
             return null;
         }
 
@@ -142,7 +142,7 @@ abstract class BaseGoPay extends GatewayAbstract
             Debugger::log("Gopay response data doesn't include state: " . Json::encode($data), ILogger::WARNING);
             return false;
         }
-        return $data['state'] === self::STATE_CREATED;
+        return $this->isPendingState($data['state']);
     }
 
     protected function handleSuccessful($response)
@@ -324,5 +324,10 @@ abstract class BaseGoPay extends GatewayAbstract
             }
         }
         return $this->applicationConfig->get('site_title');
+    }
+
+    protected function isPendingState(string $state): bool
+    {
+        return in_array($state, [self::STATE_CREATED, self::STATE_PAYMENT_METHOD_CHOSEN]);
     }
 }


### PR DESCRIPTION
Sometimes gopay returns PAYMENT_METHOD_CHOSEN state instead of created after the payment was intialized. But the omnipay library used on the other hand accepts as successful only the created state, which can create problems in the checkChargeStatus method. The payment is considered as failed, but really it is still pending and should wait for the notification. https://help.gopay.com/cs/tema/integrace-platebni-brany/nastaveni-a-funkcionality-plateb/popis-prubehu-a-vyprseni-platby?pure=